### PR TITLE
Fixed scrollbar always being visible on some older systems

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -29,7 +29,7 @@ html {
     height: 70vh;
     width: 80vw;
     overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-y: auto;
     border-radius: 25px;
     border-width: 3px;
     border-style: solid;


### PR DESCRIPTION
Windows 11 always hid the scrollbar when it was not needed, but looks like this didn't happen on some operating systems.